### PR TITLE
feat(partial_freeze): create new joint partial freeze

### DIFF
--- a/multilingual_eval/tokenization/chinese_segmenter.py
+++ b/multilingual_eval/tokenization/chinese_segmenter.py
@@ -3,17 +3,16 @@ from time import sleep
 import os
 from subprocess import Popen, PIPE, DEVNULL
 from nltk.parse.corenlp import CoreNLPParser
-import threading
 import sys
 import logging
+import threading
 
 
 def filtered_stderr_logger(p):
     for line in p.stderr:
-        text = line.decode()
-        if len(text.split()) > 2 and text.split()[1] == "INFO":
+        if len(line.split()) > 2 and line.split()[1] == "INFO":
             continue
-        print(text, file=sys.stderr)
+        print(f"Stanford Segmenter subprocess: {line.strip()}", file=sys.stderr)
 
 
 class StanfordSegmenter:
@@ -52,7 +51,7 @@ class StanfordSegmenter:
                 logging.error(f"Got HTTPError with following sentence: {repr(part)}")
                 raise e
             tokens += [
-                token["originalText"] or token["word"]
+                token["originalline"] or token["word"]
                 for sentence in result["sentences"]
                 for token in sentence["tokens"]
             ]
@@ -66,10 +65,12 @@ class StanfordSegmenter:
                     f"tools/stanford-corenlp-full-2016-10-31 does not exist, please install the Stanford Segmenter (download_resources/stanford_tokenizer.sh)"
                 )
             self.server_process = Popen(
-                ["/bin/bash", "subscripts/launch_corenlp_server.sh", str(self.port)], stderr=sys.stderr, stdout=DEVNULL
+                ["/bin/bash", "subscripts/launch_corenlp_server.sh", str(self.port)], stderr=PIPE, stdout=DEVNULL, universal_newlines=True
             )
 
             self.segmenter = CoreNLPParser(f"http://localhost:{self.port}", encoding="utf8")
+            self.log_thread = threading.Thread(target=filtered_stderr_logger, args=(self.server_process,), daemon=True)
+            self.log_thread.start()
             sleep(2)
             self.start_and_wait_for_availability()
 
@@ -80,12 +81,12 @@ class StanfordSegmenter:
             self.segmenter.api_call(
                 "只是教授和警察双方都对不尊重的暗示表现得过于敏感", {"annotators": "tokenize,ssplit"}, timeout=1
             )
-        except (requests.exceptions.ConnectionError, ConnectionRefusedError) as e:
+        except (requests.exceptions.ConnectionError, ConnectionRefusedError, requests.exceptions.HTTPError) as e:
             sleep(wait)
             self.start_and_wait_for_availability(max_iter=max_iter - 1, wait=wait * 2)
 
     def cleanup(self):
         if self.server_process is not None:
             self.server_process.terminate()
-
+            self.log_thread = None
         self.segmenter = None

--- a/multilingual_eval/tokenization/chinese_segmenter.py
+++ b/multilingual_eval/tokenization/chinese_segmenter.py
@@ -17,10 +17,11 @@ def filtered_stderr_logger(p):
 
 
 class StanfordSegmenter:
-    def __init__(self):
+    def __init__(self, port=9001):
         self.segmenter = None
         self.server_process = None
         self.entered = False
+        self.port = port
 
     def __enter__(self):
         self.entered = True
@@ -65,10 +66,10 @@ class StanfordSegmenter:
                     f"tools/stanford-corenlp-full-2016-10-31 does not exist, please install the Stanford Segmenter (download_resources/stanford_tokenizer.sh)"
                 )
             self.server_process = Popen(
-                ["/bin/bash", "subscripts/launch_corenlp_server.sh"], stderr=DEVNULL, stdout=DEVNULL
+                ["/bin/bash", "subscripts/launch_corenlp_server.sh", str(self.port)], stderr=DEVNULL, stdout=DEVNULL
             )
 
-            self.segmenter = CoreNLPParser("http://localhost:9001", encoding="utf8")
+            self.segmenter = CoreNLPParser(f"http://localhost:{self.port}", encoding="utf8")
             sleep(2)
             self.start_and_wait_for_availability()
 

--- a/multilingual_eval/tokenization/chinese_segmenter.py
+++ b/multilingual_eval/tokenization/chinese_segmenter.py
@@ -66,7 +66,7 @@ class StanfordSegmenter:
                     f"tools/stanford-corenlp-full-2016-10-31 does not exist, please install the Stanford Segmenter (download_resources/stanford_tokenizer.sh)"
                 )
             self.server_process = Popen(
-                ["/bin/bash", "subscripts/launch_corenlp_server.sh", str(self.port)], stderr=DEVNULL, stdout=DEVNULL
+                ["/bin/bash", "subscripts/launch_corenlp_server.sh", str(self.port)], stderr=sys.stderr, stdout=DEVNULL
             )
 
             self.segmenter = CoreNLPParser(f"http://localhost:{self.port}", encoding="utf8")

--- a/multilingual_eval/training/training_loops.py
+++ b/multilingual_eval/training/training_loops.py
@@ -530,6 +530,8 @@ def realignment_training_loop(
             prefixes_to_ignore = [f"{encoder_prefix}.{i}" for i in range(n_layers // 2)]
         elif strategy.endswith("back"):
             prefixes_to_ignore = [f"{encoder_prefix}.{i}" for i in range(n_layers // 2, n_layers)]
+        elif strategy.endswith("none"):
+            prefixes_to_ignore = []
         else:
             raise NotImplementedError(f"Unrecognized strategy {strategy}")
         
@@ -563,6 +565,7 @@ def realignment_training_loop(
                             "before+during", 
                             "during_partial_freeze_front",
                             "during_partial_freeze_back",
+                            "during_partial_freeze_none",
                             "staged"]
             else None,
             realignment_optimizer=realignment_optimizer,

--- a/multilingual_eval/training/training_loops.py
+++ b/multilingual_eval/training/training_loops.py
@@ -514,8 +514,9 @@ def realignment_training_loop(
     
     realignment_optimizer = None
     realignment_scheduler = None
+    realignment_ignore_parameters = []
     if strategy.startswith("during_partial_freeze"):
-        realigned_parameters = []
+
 
         if "roberta" in model_name:
             n_layers = len(model.roberta.encoder.layer)
@@ -537,17 +538,7 @@ def realignment_training_loop(
         
         for name, param in model.named_parameters():
             if any(map(lambda x: name.startswith(x), prefixes_to_ignore)):
-                continue
-            realigned_parameters.append(param)
-
-        realignment_optimizer =  Adam(realigned_parameters, lr=learning_rate, betas=(0.9, 0.999), eps=1e-8)
-        realignment_scheduler = get_scheduler(
-            "linear",
-            realignment_optimizer,
-            num_warmup_steps=int(0.1 * len(task_dataloader) * n_epochs),
-            num_training_steps=len(task_dataloader) * n_epochs,
-        )
-
+                realignment_ignore_parameters.append(name)
 
     log_layer_status(model, model_name)
 
@@ -582,7 +573,8 @@ def realignment_training_loop(
             training_state=training_state,
             log_first_sample=i == 0,
             realignment_steps_by_finetuning=realignment_steps_by_finetuning,
-            separate_backward=strategy == "during_separate_backward"
+            separate_backward=strategy == "during_separate_backward" or bool(realignment_ignore_parameters),
+            realignment_ignore_parameters=realignment_ignore_parameters
         )
         for callback in epoch_callbacks:
             callback(model)

--- a/multilingual_eval/training/training_loops.py
+++ b/multilingual_eval/training/training_loops.py
@@ -519,10 +519,10 @@ def realignment_training_loop(
 
         if "roberta" in model_name:
             n_layers = len(model.roberta.encoder.layer)
-            encoder_prefix = "model.roberta.encoder.layer"
+            encoder_prefix = "roberta.encoder.layer"
         elif "distilbert" in model_name:
             n_layers = len(model.distilbert.transformer.layer)
-            encoder_prefix = "model.distilbert.transformer.layer"
+            encoder_prefix = "distilbert.transformer.layer"
         else:
             raise NotImplementedError(f"during_partial_freeze_* strategies are not implemented for model {model}")
         

--- a/multilingual_eval/training/training_loops.py
+++ b/multilingual_eval/training/training_loops.py
@@ -559,6 +559,7 @@ def realignment_training_loop(
             task_dataloader=task_dataloader,
             realignment_dataloader=realignment_dataloader
             if strategy in ["during",
+                            "during_separate_backward",
                             "during_freeze_realign_unfreeze",
                             "during_freeze_realign_unfreeze_last_6",
                             "during_freeze_realign_unfreeze_last_half",
@@ -581,6 +582,7 @@ def realignment_training_loop(
             training_state=training_state,
             log_first_sample=i == 0,
             realignment_steps_by_finetuning=realignment_steps_by_finetuning,
+            separate_backward=strategy == "during_separate_backward"
         )
         for callback in epoch_callbacks:
             callback(model)

--- a/scripts/2023_acl/controlled_realignment.py
+++ b/scripts/2023_acl/controlled_realignment.py
@@ -327,6 +327,11 @@ if __name__ == "__main__":
         dest="use_wandb",
         help="Use this option to use wandb (but must be installed first)",
     )
+    parser.add_argument(
+        "--segmenter_port",
+        type=int,
+        default=9001
+    )
     parser.set_defaults(debug=False, large_gpu=False, use_wandb=False)
     args = parser.parse_args()
 
@@ -353,7 +358,7 @@ if __name__ == "__main__":
             "seed"
         ]["values"][:1]
 
-    with StanfordSegmenter() as zh_segmenter:  # Calls Stanford Segmenter in another process, hence the context manager
+    with StanfordSegmenter(port=args.segmenter_port) as zh_segmenter:  # Calls Stanford Segmenter in another process, hence the context manager
         if args.use_wandb:
             import wandb
 

--- a/subscripts/launch_corenlp_server.sh
+++ b/subscripts/launch_corenlp_server.sh
@@ -1,4 +1,6 @@
+PORT=$1
+
 cd tools/stanford-corenlp-full-2016-10-31 && java -Xmx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer \
 -serverProperties StanfordCoreNLP-chinese.properties \
 -preload tokenize,ssplit,pos,lemma,ner,parse \
--status_port 9001  -port 9001 -timeout 15000
+-status_port $PORT  -port $PORT -timeout 15000


### PR DESCRIPTION
This PR introduces the following main change: 

It fixes the newly proposed partial joint realignment method by fixing the parameters named such that they are freezed and by using only one optimizer. 

The method to backpropagate only the task loss through the earlier layer follows those steps in each iteration of joint training:

- forward pass for realignment
- backward pass for realignment (with `realignment_loss.backward()`
- setting the gradients of the selected parameters to `None`
- forward pass for the task
- backward pass for the task (with `task_loss.backward()`)

This PR also introduces a few changes to solve some light issues:

- For the chinese segmenter, a new thread has been created to log potential errors that we might encounter in the subprocess launching the java Stanford segmenter 
- For the chinese segmenter, the port on which is it launched is now parametrizable. So, if the port is already taken, when launching `python scripts/2023_acl/controlled_realignment.py`, you can use the option `--segmenter_port 9000` and increase this value if the port is already taken. You must also use different values for this port for each instance of the script that is launched simultaneously on the same machine
- Improved the alternative to wandb where results are stored to a CSV file, now if the CSV already exists, the program checked for the runs that have already been run and ignore them, allowing to restart from a previous sweep similarly to wandb
